### PR TITLE
Updates the AMI ID to be one found in the training aws

### DIFF
--- a/cookbooks/myiis/.kitchen.yml
+++ b/cookbooks/myiis/.kitchen.yml
@@ -24,7 +24,7 @@ verifier:
 platforms:
   - name: windows-2012r2
     driver_config:
-      image_id: ami-ca82c4a0
+      image_id: ami-4a80ac20
     transport:
       username: Administrator
       password: Cod3Can!

--- a/cookbooks/workstation/.kitchen.yml
+++ b/cookbooks/workstation/.kitchen.yml
@@ -24,7 +24,7 @@ verifier:
 platforms:
   - name: windows-2012r2
     driver_config:
-      image_id: ami-ca82c4a0
+      image_id: ami-4a80ac20
     transport:
       username: Administrator
       password: Cod3Can!


### PR DESCRIPTION
The previously specified training AWS ID is owned by another organization.